### PR TITLE
fix: Ensure we use env variables in docker-compose.yml

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,13 @@
+# --- Image Versions ---
+MODEL_SERVICE_TAG=latest
+APP_SERVICE_TAG=latest
+APP_FRONTEND_TAG=latest
+
+# --- Configuration ---
+MODEL_PORT=8081
+APP_PORT=8080
+MODEL_PATH=./model
+
+# --- Model Configuration ---
+MODEL_FILENAME=model-latest.pkl
+MODEL_URL=https://github.com/doda25-team10/model-service/releases/latest/download/model.pkl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,25 @@
 services:
   model-service:
-    image: ghcr.io/doda25-team10/model-service:latest
+    image: ghcr.io/doda25-team10/model-service:${MODEL_SERVICE_TAG:-latest}
     ports:
-      - "8081:8081"
+      - "${MODEL_PORT:-8081}:8081"
     environment:
-      - PORT=8081
+      - PORT=${MODEL_PORT:-8081}
     volumes:
       # Expects the models to be in a local 'model/' directory
       # The models are mounted to '/root/sms/output' in the container 
-      - ./model:/root/sms/output
+      - ${MODEL_PATH:-./model}:/root/sms/output
 
     # Always restarts the container if any failure occurs, unless it is explicitly stopped
     restart: unless-stopped
 
   app-service:
-    image: ghcr.io/doda25-team10/app-service:latest
+    image: ghcr.io/doda25-team10/app-service:${MODEL_SERVICE_TAG:-latest}
     ports:
-      - "8080:8080"
+      - "${APP_PORT:-8080}:8080"
     environment:
-      - PORT=8080
+      - PORT=${APP_PORT:-8080}
       - MODEL_HOST=http://model-service:8081
-      
+
     # Always restarts the container if any failure occurs, unless it is explicitly stopped
     restart: unless-stopped


### PR DESCRIPTION
Just changed docker-compose.yml so it uses variables from our .env file (I think it is a part of requirements).