### PR TITLE
chore: update tagStable and tagExperiment

### DIFF
--- a/helm/myapp/values.yaml
+++ b/helm/myapp/values.yaml
@@ -11,8 +11,8 @@ app:
   replicaCount: 2
   image:
     repository: "ghcr.io/doda25-team10/app"
-    tagStable: "0.0.10"
-    tagExperiment: "0.0.11"
+    tagStable: "0.0.11"
+    tagExperiment: "0.0.12"
     pullPolicy: Always
   service:
     type: ClusterIP


### PR DESCRIPTION
In `app` repo I updated the `a4-experimental` with the code from main. In addition, I updated the version of `main` and `experimental` to `0.0.11` and `0.0.12`. Here is just an updated helm chart versions to app `0.0.11`.