### PR TITLE
Add stable canary header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv
 model
 kubeconfig
 istio-1*
+cookies.txt

--- a/helm/myapp/README.md
+++ b/helm/myapp/README.md
@@ -260,14 +260,16 @@ should work exactly as expected and should not contain any abnormal behaviour. W
 When you access {URL}/sms from the experimental version, the UI should be different and any message you will classify should *always* return spam. 
 The classification always returning spam is simply so we can show the experimental app and model go hand in hand.
 Once you access the app and a get specific version, you are stuck with it for a certain amount of time. 
-You can see which version you have in your cookies, these are named v1 and v2, and you can delete these 
-and refresh your page as often as you want in order to be convinced the 90/10 split is correctly implemented.
-11. We can do the same using curl requests, but this works a little differently. Classifying a message using the
-stable Canary header `curl -X POST http://{EXTERNAL_IP}/sms/ -H "Content-Type: application/json" -H "canary stable" -d '{"sms": "hi"}'` 
-should *always* return the correct output (`{"classifier":null,"result":"ham","sms":"hi","guess":null}` in the case of our message).
-When we add the experimental header, `curl -X POST http://{EXTERNAL_IP}/sms/   -H "Content-Type: application/json" -H "canary: experimental" -d '{"sms": "hi"}'`, you should
-*always* get `{"classifier":null,"result":"spam","sms":"hi","guess":null}` regardless of the message.
-When we don't add any Canary header, you should get a 90/10 split of ham/spam returned. 
+You can see which version you have in your cookies, these are named v1 and v2 for the stable and experimental version respectively, 
+and you can delete these and refresh your page as often as you want in order to be convinced the 90/10 split is correctly implemented.
+11. This can be done using curl requests as well by running 
+`curl -X POST http://{EXTERNAL_IP}/sms/ -H "Content-Type: application/json" -d '{"sms": "hi"}' -c cookies.txt`. This will
+save the received cookies in a `cookies.txt` file in the directory your terminal is opened in. You can open this file and verify
+which version you have (v1/v2). To send these cookies, run the command `curl -X POST http://{EXTERNAL_IP}/sms/ -H "Content-Type: application/json" -d '{"sms": "hi"}' -b cookies.txt`
+For v1, you should *always* get the correct output (`{"classifier":null,"result":"ham","sms":"hi","guess":null}` in the case of our message).
+For v2, you should *always* get spam returned (`{"classifier":null,"result":"spam","sms":"hi","guess":null}`), regardless of the message.
+To force the versions, you can add the flag `-H "Canary: stable` for v1 and `-H "Canary: experimental"` for v2. Using no cookies and no headers will 
+result in a 90/10 split for v1 and v2 respectively.
 
 General information:
 The default Ingress Gateway selector is set to `ingressgateway`. If deploying to a cluster where the Istio Ingress Gateway 

--- a/helm/myapp/README.md
+++ b/helm/myapp/README.md
@@ -262,12 +262,12 @@ The classification always returning spam is simply so we can show the experiment
 Once you access the app and a get specific version, you are stuck with it for a certain amount of time. 
 You can see which version you have in your cookies, these are named v1 and v2, and you can delete these 
 and refresh your page as often as you want in order to be convinced the 90/10 split is correctly implemented.
-11. We can do the same using curl requests, but this works a little differently. Classifying a message using
-`curl -X POST http://{EXTERNAL_IP}/sms/   -H "Content-Type: application/json"  -d '{"sms": "hi"}'` should return the correct
-output 90% of the time (`{"classifier":null,"result":"ham","sms":"hi","guess":null}` in the case of our message), 
-and spam 10% of the time (`{"classifier":null,"result":"spam","sms":"hi","guess":null}`). When we add the Canary "bypass" header, 
-`curl -X POST http://{EXTERNAL_IP}/sms/   -H "Content-Type: application/json" -H "canary: enabled"  -d '{"sms": "hi"}'`, you should
+11. We can do the same using curl requests, but this works a little differently. Classifying a message using the
+stable Canary header `curl -X POST http://{EXTERNAL_IP}/sms/ -H "Content-Type: application/json" -H "canary stable" -d '{"sms": "hi"}'` 
+should *always* return the correct output (`{"classifier":null,"result":"ham","sms":"hi","guess":null}` in the case of our message).
+When we add the experimental header, `curl -X POST http://{EXTERNAL_IP}/sms/   -H "Content-Type: application/json" -H "canary: experimental" -d '{"sms": "hi"}'`, you should
 *always* get `{"classifier":null,"result":"spam","sms":"hi","guess":null}` regardless of the message.
+When we don't add any Canary header, you should get a 90/10 split of ham/spam returned. 
 
 General information:
 The default Ingress Gateway selector is set to `ingressgateway`. If deploying to a cluster where the Istio Ingress Gateway 

--- a/helm/myapp/templates/istio-virtualservice.yaml
+++ b/helm/myapp/templates/istio-virtualservice.yaml
@@ -22,11 +22,19 @@ spec:
     - match:
         - headers:
             {{ .Values.istio.canary.header | default "canary" }}:
-              exact: {{ .Values.istio.canary.headerValue | default "enabled" | quote }}
+              exact: {{ .Values.istio.canary.experimentalHeaderValue | default "experimental" | quote }}
       route:
         - destination:
             host: {{ include "myapp.appServiceName" . }}
             subset: v2
+    - match:
+        - headers:
+            {{ .Values.istio.canary.header | default "canary" }}:
+              exact: {{ .Values.istio.canary.stableHeaderValue | default "stable" | quote }}
+      route:
+        - destination:
+            host: {{ include "myapp.appServiceName" . }}
+            subset: v1
     - match:
         - headers:
             cookie:

--- a/helm/myapp/values.yaml
+++ b/helm/myapp/values.yaml
@@ -139,7 +139,8 @@ istio:
 
   canary:
     header: "canary"
-    headerValue: "enabled"
+    experimentalHeaderValue: "experimental"
+    stableHeaderValue: "stable"
     stableCookie: "user_group=v1; Path=/; Max-Age=86400"
     experimentalCookie: "user_group=v2; Path=/; Max-Age=86400"
 


### PR DESCRIPTION
```
Use  Sticky Sessions to stabilize the routing for a user, i.e., if selected for the experiment, a user would only see
the new version when reloading. If not, users would never see the new version. You do not have to implement a
full CE system for organizing your experiments or partitioning your users. To keep things simple, it is ok if you use
illustrative curl or Postman requests (e.g., with special headers) to illustrate correct routing in the backend
```

This is from assignment A4, and you should focus on `if not, users would never see the new version`.  Initially, we only had a Canary 'bypass' header, which allowed us to consistently get V2, but imo we should also have a way to consistently see v1, as that mimicks a person who hasn't been selected. So that's what I added. 

Also i added instructions on how to use cookies using curl requets.

In retrospect, we might not even need the headers if we use the cookies in curl requests as well. Lmk what u guys think. Just follow the traffic management instructions in the helm readme if you wanna test