### PR TITLE
Grafana Experiment Dashboard

### DIFF
--- a/helm/myapp/dashboards/experiment-decision-dashboard.json
+++ b/helm/myapp/dashboards/experiment-decision-dashboard.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 39,
   "title": "UI Engagement – Experiment Decision Dashboard",
-  "version": 2,
+  "version": 3,
   "timezone": "browser",
   "refresh": "10s",
   "time": { "from": "now-30m", "to": "now" },
@@ -21,6 +21,18 @@
         "label": "Observation window",
         "query": "15m,30m,1h,6h,24h",
         "current": { "text": "30m", "value": "30m" }
+      },
+      {
+        "name": "stableVersion",
+        "type": "constant",
+        "label": "Stable version",
+        "query": "{{ .Values.app.image.tagStable }}"
+      },
+      {
+        "name": "experimentVersion",
+        "type": "constant",
+        "label": "Experimental version",
+        "query": "{{ .Values.app.image.tagExperiment }}"
       }
     ]
   },
@@ -29,18 +41,18 @@
       "id": 1,
       "type": "stat",
       "title": "Total predictions (spam + ham)",
-      "description": "Total predictions over the observation window. Stable UI (0.0.11) vs Experimental UI (0.0.12). Higher means more interaction.",
+      "description": "Total predictions over the observation window. Stable UI ($stableVersion) vs Experimental UI ($experimentVersion). Higher means more interaction.",
       "gridPos": { "x": 0, "y": 0, "w": 8, "h": 7 },
       "targets": [
         {
           "refId": "S",
-          "expr": "round(sum(increase(sms_predictions_total{version=\"0.0.11\"}[$window])))",
-          "legendFormat": "Stable UI (0.0.11)"
+          "expr": "round(sum(increase(sms_predictions_total{version=\"$stableVersion\"}[$window])))",
+          "legendFormat": "Stable UI ($stableVersion)"
         },
         {
           "refId": "E",
-          "expr": "round(sum(increase(sms_predictions_total{version=\"0.0.12\"}[$window])))",
-          "legendFormat": "Experimental UI (0.0.12)"
+          "expr": "round(sum(increase(sms_predictions_total{version=\"$experimentVersion\"}[$window])))",
+          "legendFormat": "Experimental UI ($experimentVersion)"
         }
       ],
       "fieldConfig": {
@@ -62,18 +74,18 @@
       "id": 2,
       "type": "stat",
       "title": "Abandonment rate (abandoned / sessions)",
-      "description": "Abandonment rate over the observation window. Stable UI (0.0.11) vs Experimental UI (0.0.12). Lower is better. Sessions proxied by time_on_page count.",
+      "description": "Abandonment rate over the observation window. Stable UI ($stableVersion) vs Experimental UI ($experimentVersion). Lower is better. Sessions proxied by time_on_page count.",
       "gridPos": { "x": 8, "y": 0, "w": 8, "h": 7 },
       "targets": [
         {
           "refId": "S",
-          "expr": "sum(increase(sms_pages_abandoned_total{version=\"0.0.11\"}[$window])) / clamp_min(sum(increase(sms_time_on_page_seconds_count{version=\"0.0.11\"}[$window])), 1)",
-          "legendFormat": "Stable UI (0.0.11)"
+          "expr": "sum(increase(sms_pages_abandoned_total{version=\"$stableVersion\"}[$window])) / clamp_min(sum(increase(sms_time_on_page_seconds_count{version=\"$stableVersion\"}[$window])), 1)",
+          "legendFormat": "Stable UI ($stableVersion)"
         },
         {
           "refId": "E",
-          "expr": "sum(increase(sms_pages_abandoned_total{version=\"0.0.12\"}[$window])) / clamp_min(sum(increase(sms_time_on_page_seconds_count{version=\"0.0.12\"}[$window])), 1)",
-          "legendFormat": "Experimental UI (0.0.12)"
+          "expr": "sum(increase(sms_pages_abandoned_total{version=\"$experimentVersion\"}[$window])) / clamp_min(sum(increase(sms_time_on_page_seconds_count{version=\"$experimentVersion\"}[$window])), 1)",
+          "legendFormat": "Experimental UI ($experimentVersion)"
         }
       ],
       "fieldConfig": {
@@ -95,18 +107,18 @@
       "id": 3,
       "type": "stat",
       "title": "Time on page (median, p50, seconds)",
-      "description": "Median time on page (p50) over the observation window. Stable UI (0.0.11) vs Experimental UI (0.0.12). Higher is better.",
+      "description": "Median time on page (p50) over the observation window. Stable UI ($stableVersion) vs Experimental UI ($experimentVersion). Higher is better.",
       "gridPos": { "x": 16, "y": 0, "w": 8, "h": 7 },
       "targets": [
         {
           "refId": "S",
-          "expr": "histogram_quantile(0.50, sum(rate(sms_time_on_page_seconds_bucket{version=\"0.0.11\"}[$window])) by (le))",
-          "legendFormat": "Stable UI (0.0.11)"
+          "expr": "histogram_quantile(0.50, sum(rate(sms_time_on_page_seconds_bucket{version=\"$stableVersion\"}[$window])) by (le))",
+          "legendFormat": "Stable UI ($stableVersion)"
         },
         {
           "refId": "E",
-          "expr": "histogram_quantile(0.50, sum(rate(sms_time_on_page_seconds_bucket{version=\"0.0.12\"}[$window])) by (le))",
-          "legendFormat": "Experimental UI (0.0.12)"
+          "expr": "histogram_quantile(0.50, sum(rate(sms_time_on_page_seconds_bucket{version=\"$experimentVersion\"}[$window])) by (le))",
+          "legendFormat": "Experimental UI ($experimentVersion)"
         }
       ],
       "fieldConfig": {

--- a/helm/myapp/dashboards/experiment-decision-dashboard.json
+++ b/helm/myapp/dashboards/experiment-decision-dashboard.json
@@ -1,0 +1,129 @@
+{
+  "schemaVersion": 39,
+  "title": "UI Engagement – Experiment Decision Dashboard",
+  "version": 2,
+  "timezone": "browser",
+  "refresh": "10s",
+  "time": { "from": "now-30m", "to": "now" },
+  "tags": ["experiment", "ui", "decision"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "pluginId": "prometheus",
+        "label": "Data Source",
+        "query": "prometheus"
+      },
+      {
+        "name": "window",
+        "type": "interval",
+        "label": "Observation window",
+        "query": "15m,30m,1h,6h,24h",
+        "current": { "text": "30m", "value": "30m" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Total predictions (spam + ham)",
+      "description": "Total predictions over the observation window. Stable UI (0.0.11) vs Experimental UI (0.0.12). Higher means more interaction.",
+      "gridPos": { "x": 0, "y": 0, "w": 8, "h": 7 },
+      "targets": [
+        {
+          "refId": "S",
+          "expr": "round(sum(increase(sms_predictions_total{version=\"0.0.11\"}[$window])))",
+          "legendFormat": "Stable UI (0.0.11)"
+        },
+        {
+          "refId": "E",
+          "expr": "round(sum(increase(sms_predictions_total{version=\"0.0.12\"}[$window])))",
+          "legendFormat": "Experimental UI (0.0.12)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "value",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Abandonment rate (abandoned / sessions)",
+      "description": "Abandonment rate over the observation window. Stable UI (0.0.11) vs Experimental UI (0.0.12). Lower is better. Sessions proxied by time_on_page count.",
+      "gridPos": { "x": 8, "y": 0, "w": 8, "h": 7 },
+      "targets": [
+        {
+          "refId": "S",
+          "expr": "sum(increase(sms_pages_abandoned_total{version=\"0.0.11\"}[$window])) / clamp_min(sum(increase(sms_time_on_page_seconds_count{version=\"0.0.11\"}[$window])), 1)",
+          "legendFormat": "Stable UI (0.0.11)"
+        },
+        {
+          "refId": "E",
+          "expr": "sum(increase(sms_pages_abandoned_total{version=\"0.0.12\"}[$window])) / clamp_min(sum(increase(sms_time_on_page_seconds_count{version=\"0.0.12\"}[$window])), 1)",
+          "legendFormat": "Experimental UI (0.0.12)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "value",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "values": false
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Time on page (median, p50, seconds)",
+      "description": "Median time on page (p50) over the observation window. Stable UI (0.0.11) vs Experimental UI (0.0.12). Higher is better.",
+      "gridPos": { "x": 16, "y": 0, "w": 8, "h": 7 },
+      "targets": [
+        {
+          "refId": "S",
+          "expr": "histogram_quantile(0.50, sum(rate(sms_time_on_page_seconds_bucket{version=\"0.0.11\"}[$window])) by (le))",
+          "legendFormat": "Stable UI (0.0.11)"
+        },
+        {
+          "refId": "E",
+          "expr": "histogram_quantile(0.50, sum(rate(sms_time_on_page_seconds_bucket{version=\"0.0.12\"}[$window])) by (le))",
+          "legendFormat": "Experimental UI (0.0.12)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 1
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "value",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "values": false
+        }
+      }
+    }
+  ]
+}

--- a/helm/myapp/templates/grafana-dashboard-configmap.yaml
+++ b/helm/myapp/templates/grafana-dashboard-configmap.yaml
@@ -8,7 +8,12 @@ metadata:
 data:
 {{- range $path, $_ := .Files.Glob "dashboards/*.json" }}
   {{ base $path }}: |-
-{{ $.Files.Get $path | indent 4 }}
+{{- $content := $.Files.Get $path -}}
+{{- if contains "{{ .Values" $content }}
+{{ tpl $content $ | indent 4 }}
+{{- else }}
+{{ $content | indent 4 }}
+{{- end }}
 {{- end }}
 ---
 apiVersion: v1


### PR DESCRIPTION
## How to test

### 1) Provision the cluster (Vagrant + Ansible)

From the `operation` repo:

```bash
vagrant up
ansible-playbook -u vagrant -i 192.168.56.100, ./provisioning/finalization.yml --private-key <path-to-identityfile>
```
---

### 2) Install Istio and deploy cluster

```bash
curl -L https://istio.io/downloadIstio | sh -
cd istio-*
export PATH=$PWD/bin:$PATH

istioctl install -y
kubectl label namespace sms-stack istio-injection=enabled --overwrite

minikube start
```

---

### 3) Deploy the stack with Helm


```bash
helm upgrade --install myapp ./helm/myapp -n sms-stack --create-namespace
```

---

### 4) Access Grafana

```bash
kubectl -n sms-stack port-forward svc/myapp-grafana-svc 3000:3000
```

Open:

* Grafana: [http://localhost:3000/](http://localhost:3000) (admin/admin)

---

### 5) Generate traffic for both versions and verify metrics

Tunnel and fetch the external IP:

```bash
minikube tunnel
kubectl get svc -n istio-system istio-ingressgateway
```

Look for EXTERNAL-IP and open:

http://EXTERNAL-IP/sms

Generate traffic:

* Submit several SMS messages on the UI (spam/ham predictions).
* Open/close the SMS page to generate time-on-page and abandonment signals.
* Ensure both versions receive traffic (depending on Istio routing/canary logic).

Finally, open the Grafana dashboard:

* **UI Engagement – Experiment Decision Dashboard**
  and confirm both series appear:
* **Stable UI (0.0.11)**
* **Experimental UI (0.0.12)**

---

## Metrics collected and how they’re calculated

All metrics are grouped by the label: `version="0.0.11"` (stable) or `version="0.0.12"` (experimental).

### 1) Total predictions (interaction volume)

**Raw metric:** `sms_predictions_total{result="spam|ham", version="..."}` (counter)

**Dashboard calculation (per version):**

```promql
round(sum(increase(sms_predictions_total{version="X"}[$window])))
```

**Interpretation:** Higher = more user interaction (more prediction actions performed).

---

### 2) Abandonment rate

**Raw metrics:**

* `sms_pages_abandoned_total{version="..."}` (counter)
* `sms_time_on_page_seconds_count{version="..."}` (histogram count → used as sessions proxy)

**Dashboard calculation (per version):**

```promql
sum(increase(sms_pages_abandoned_total{version="X"}[$window]))
/
clamp_min(sum(increase(sms_time_on_page_seconds_count{version="X"}[$window])), 1)
```

**Interpretation:** Lower = fewer users abandoning (leaving without completing engagement).

---

### 3) Time on page (median / p50)

**Raw metric:** `sms_time_on_page_seconds_bucket{le="...", version="..."}` (histogram buckets)

**Dashboard calculation (per version):**

```promql
histogram_quantile(0.50,
  sum(rate(sms_time_on_page_seconds_bucket{version="X"}[$window])) by (le)
)
```

The median session
**Interpretation:** Higher = users stay longer on the page.
