### PR TITLE
 renamed prometheus config to serviceMonitor as we had prometheus 2 t…

### DIFF
--- a/helm/myapp/README.md
+++ b/helm/myapp/README.md
@@ -91,13 +91,11 @@ Key sections:
 - `global.storage.hostPath`: path on the node and mount path inside the pod (defaults to `/mnt/shared`).
 - `app.*`: image, replica count, env vars, ConfigMap data, SMTP credentials (stored via stringData), and the ingress/service definition. By default the ingress renders both a **stable** host (enabled) and a **preview** host (disabled) via `app.ingress.hosts`. Leave `app.secret.smtpPassword` empty (with `autogenerate: true`) to have Helm create a random password during install.
 - `model.*`: Values similar to the app, without any ingress or secrets.
-- `prometheus`: Prometheus config, installed through kube-promeheus-stack
-- `kube-prometheus-stack`: collection which contains prometheus and the alertmanager.
+- `serviceMonitor.*`: configures the ServiceMonitor resource that enables kube-prometheus-stack to discover and scrape metrics from the application. Note: this does NOT deploy a standalone Prometheus; it only creates a ServiceMonitor resource.
+- `kube-prometheus-stack`: the monitoring stack subchart which contains Prometheus and Alertmanager.
 - `alertmanager`: placeholder for the required (secret) app password.
 - `grafana.*`: manages Grafana image, admin credentials, service type, and which dashboard file should act as the default home.
 - `experiments.preview.*`: future Assignment 4 knobs (currently disabled) that will control preview traffic weight, image overrides, or extra env vars once experimentation features are added.
-- `prometheus.*`: toggles the standalone Prometheus deployment/service, scrape interval and ServiceMonitor emission
-- `grafana.*`: manages Grafana image, admin credentials, service type, and which dashboard file should act as the default home.
 
 Example production overlay:
 
@@ -120,9 +118,10 @@ app:
         enabled: true
         host: "canary.prod.example.com"
         tlsSecretName: "spam-preview-tls"
-prometheus:
-  serviceMonitor:
-    namespace: observability
+serviceMonitor:
+  enabled: true
+  interval: "5s"
+  path: "/sms/metrics"
 grafana:
   adminPassword: "use-a-secret-manager"
 ```

--- a/helm/myapp/templates/grafana-dashboard-configmap.yaml
+++ b/helm/myapp/templates/grafana-dashboard-configmap.yaml
@@ -38,6 +38,6 @@ data:
       - name: Prometheus
         type: prometheus
         access: proxy
-        url: http://{{ .Release.Name }}-kube-prometheus-stac-prometheus:{{ .Values.prometheus.service.port }}
+        url: http://{{ .Release.Name }}-kube-prometheus-prometheus:{{ .Values.serviceMonitor.prometheusPort }}
         isDefault: true
 {{- end }}

--- a/helm/myapp/templates/servicemonitor.yaml
+++ b/helm/myapp/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.prometheus.enabled .Values.prometheus.serviceMonitor.enabled }}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -18,7 +18,7 @@ spec:
   
 
   endpoints:
-    - interval: {{ .Values.prometheus.serviceMonitor.interval }}
+    - interval: {{ .Values.serviceMonitor.interval }}
       port: http
-      path: {{ .Values.prometheus.serviceMonitor.path }}
+      path: {{ .Values.serviceMonitor.path }}
 {{- end }}

--- a/helm/myapp/values.yaml
+++ b/helm/myapp/values.yaml
@@ -56,7 +56,6 @@ serviceMonitor:
   enabled: true
   interval: "5s"
   path: "/sms/metrics"
-  # Port of kube-prometheus-stack's Prometheus service (used by Grafana datasource)
   prometheusPort: 9090
 
 kube-prometheus-stack:

--- a/helm/myapp/values.yaml
+++ b/helm/myapp/values.yaml
@@ -52,15 +52,12 @@ model:
   env: {}
   resources: {}
 
-prometheus:
+serviceMonitor:
   enabled: true
-  serviceMonitor:
-    enabled: true
-    interval: "5s"
-    path: "/sms/metrics"
-  service:
-      type: ClusterIP
-      port: 9090
+  interval: "5s"
+  path: "/sms/metrics"
+  # Port of kube-prometheus-stack's Prometheus service (used by Grafana datasource)
+  prometheusPort: 9090
 
 kube-prometheus-stack:
   enabled: true


### PR DESCRIPTION
To test if it is working correctly and it is directed to where it should. 
```cd opeartion/helm/myapp```
then 
```helm lint . ```

To render ServiceMonitor:
```helm template sms-stack . -s templates/servicemonitor.yaml```

to render Grafana resources:
```helm template sms-stack . -s templates/grafana-dashboard-configmap.yaml```

If the ``` helm lint . ``` shows 0 errors and Grafana datasource URL shows 

``` 
datasources: 
      - name: Prometheus 
        type: prometheus 
        access: proxy 
        url: http://sms-stack-kube-prometheus-prometheus:9090 
        isDefault: true 
```
        
then it is working fine